### PR TITLE
FEED-179: Fix different endpoints for different usages

### DIFF
--- a/src/actions/feedback.js
+++ b/src/actions/feedback.js
@@ -55,11 +55,11 @@ export function fetchFeedbackAsReceiver(
   };
 }
 
-export function editFeedback(props, accessToken) {
+export function editFeedback(props, accessToken, type = 'give') {
   const request = axios({
     method: 'PATCH',
     data: props,
-    url: `${ROOT_URL}/feedbacks/${props.id}/`,
+    url: `${ROOT_URL}/feedback/${type}/${props.id}/`,
     headers: { Authorization: `Bearer ${accessToken}` }
   });
 
@@ -69,10 +69,10 @@ export function editFeedback(props, accessToken) {
   };
 }
 
-export function fetchFeedback(accessToken, id) {
+export function fetchFeedback(accessToken, id, type = 'give') {
   const requestFeedback = axios({
     method: 'GET',
-    url: `${ROOT_URL}/feedbacks/${id}/`,
+    url: `${ROOT_URL}/feedback/${type}/${id}/`,
     headers: { Authorization: `Bearer ${accessToken}` }
   });
 

--- a/src/pages/ReceivedFeedback.js
+++ b/src/pages/ReceivedFeedback.js
@@ -55,7 +55,7 @@ let ReceivedFeedbackClass = class ReceivedFeedback extends React.Component {
     let accessToken = this.props.user.user.access_token;
 
     this.props
-      .fetchFeedback(accessToken, this.props.match.params.feedbackId)
+      .fetchFeedback(accessToken, this.props.match.params.feedbackId, 'receive')
       .then(response => {
         if (response.payload.status === 200) {
           const {
@@ -96,7 +96,8 @@ let ReceivedFeedbackClass = class ReceivedFeedback extends React.Component {
           how_valuable,
           actionable_content: actionableContent
         },
-        accessToken
+        accessToken,
+        'receive'
       )
       .then(response => {
         if (response.payload.status !== 200) {


### PR DESCRIPTION
Test if giving, receiving, rating and requesting feedback still works. For this change you need to check `feature/filter-to-not-be-able-to-edit-received-feedback` out on the backend repo.