### PR TITLE
FEED-183: Added prefixes to tables and other views

### DIFF
--- a/src/components/FeedbackRow.jsx
+++ b/src/components/FeedbackRow.jsx
@@ -49,7 +49,7 @@ const FeedbackRow = props => {
   return (
     <tr>
       <td data-label="Person">
-        {person.first_name} {person.last_name}
+        {person.first_name} {person.prefix } {person.last_name}
       </td>
       <td data-label="Role">
         {role && (

--- a/src/components/ReceivedFeedbackContent.js
+++ b/src/components/ReceivedFeedbackContent.js
@@ -28,7 +28,7 @@ const ReceivedFeedbackContent = props => {
         <tbody>
           <tr>
             <td data-label="Person">
-              {person.first_name} {person.last_name}
+              {person.first_name} {person.prefix} {person.last_name}
             </td>
             <td data-label="Role">
               <RoleModalButton accessToken={accessToken} role={role.id}>
@@ -63,7 +63,7 @@ const ReceivedFeedbackContent = props => {
         <tbody>
           <tr>
             <td data-label="Person">
-              {person.first_name} {person.last_name}
+              {person.first_name} {person.prefix} {person.last_name}
             </td>
           </tr>
         </tbody>

--- a/src/pages/CheckPersonalFeedback.js
+++ b/src/pages/CheckPersonalFeedback.js
@@ -107,7 +107,7 @@ class CheckPersonalFeedback extends React.Component {
               <tbody>
                 <tr>
                   <td data-label="Person">
-                    {person.first_name} {person.last_name}
+                    {person.first_name} {person.prefix} {person.last_name}
                   </td>
                 </tr>
               </tbody>

--- a/src/pages/CheckRoleFeedback.js
+++ b/src/pages/CheckRoleFeedback.js
@@ -115,7 +115,7 @@ class CheckRoleFeedback extends React.Component {
               <tbody>
                 <tr>
                   <td data-label="Person">
-                    {person.first_name} {person.last_name}
+                    {person.first_name} {person.prefix} {person.last_name}
                   </td>
                   {role && (
                     <td data-label="Role">

--- a/src/pages/EditPersonalFeedback.js
+++ b/src/pages/EditPersonalFeedback.js
@@ -154,7 +154,7 @@ let EditPersonalFeedbackClass = class EditPersonalFeedback extends React.Compone
               <tbody>
                 <tr>
                   <td data-label="Person">
-                    {person.first_name} {person.last_name}
+                    {person.first_name} {person.prefix} {person.last_name}
                   </td>
                 </tr>
               </tbody>

--- a/src/pages/EditRoleFeedback.js
+++ b/src/pages/EditRoleFeedback.js
@@ -174,7 +174,7 @@ let EditRoleFeedbackClass = class EditRoleFeedback extends React.Component {
               <tbody>
                 <tr>
                   <td data-label="Person">
-                    {person.first_name} {person.last_name}
+                    {person.first_name} {person.prefix} {person.last_name}
                   </td>
                   <td data-label="Role">
                     <RoleModalButton accessToken={accessToken} role={role.id}>

--- a/src/pages/GivePersonalFeedback.js
+++ b/src/pages/GivePersonalFeedback.js
@@ -155,7 +155,7 @@ let GivePersonalFeedbackClass = class GivePersonalFeedback extends Component {
               <tbody>
                 <tr>
                   <td data-label="Person">
-                    {person.first_name} {person.last_name}
+                    {person.first_name} {person.prefix} {person.last_name}
                   </td>
                 </tr>
               </tbody>

--- a/src/pages/GiveRoleFeedback.js
+++ b/src/pages/GiveRoleFeedback.js
@@ -173,7 +173,7 @@ let GiveRoleFeedbackClass = class GiveRoleFeedback extends Component {
               <tbody>
                 <tr>
                   <td data-label="Person">
-                    {person.first_name} {person.last_name}
+                    {person.first_name} {person.prefix} {person.last_name}
                   </td>
                   <td data-label="Role">
                     <RoleModalButton accessToken={accessToken} role={role.id}>


### PR DESCRIPTION
This fixes Jaap Jan de Boer, being displayed as Jaap Boer in Flindt.